### PR TITLE
ci: add optional MCP Trust Kit scan

### DIFF
--- a/.github/workflows/mcp-trust.yml
+++ b/.github/workflows/mcp-trust.yml
@@ -1,0 +1,38 @@
+name: Optional MCP Trust Scan
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  mcp-trust:
+    name: Surface Risk Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run MCP Trust Kit
+        uses: aak204/MCP-Trust-Kit@v0.4.0
+        with:
+          cmd: npm run serve:stdio
+          sarif-out: mcp-trust-report.sarif
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: mcp-trust-report.sarif

--- a/.github/workflows/mcp-trust.yml
+++ b/.github/workflows/mcp-trust.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
 
       - name: Run MCP Trust Kit
-        uses: aak204/MCP-Trust-Kit@v0.4.0
+        uses: aak204/MCP-Trust-Kit@5d37f99e3cdfd703e4fe75aa88969475d1970e28
         with:
           cmd: npm run serve:stdio
           sarif-out: mcp-trust-report.sarif

--- a/README.md
+++ b/README.md
@@ -616,6 +616,14 @@ The project uses strict TypeScript settings for maximum type safety. Key configu
 | `npm run gen:prompt` | Generate a new prompt with test |
 | `npm run gen:resource` | Generate a new resource with test |
 
+### Optional CI hardening
+
+If you want a small optional GitHub Actions example for repos created from this template, see
+`.github/workflows/mcp-trust.yml`.
+
+It runs an MCP Trust Kit surface-risk scan against `npm run serve:stdio`, uploads SARIF to GitHub
+code scanning, and stays `workflow_dispatch`-only by default so it does not change the existing CI gates.
+
 ## 🔌 Integration
 
 ### How MCP Integration Works


### PR DESCRIPTION
This adds a small optional GitHub Actions workflow example using MCP Trust Kit.

What changed:
- added .github/workflows/mcp-trust.yml
- added a short README note pointing to the workflow

Why this is useful:
- gives repos created from this starter a copy-paste-friendly surface-risk check
- uploads SARIF to GitHub code scanning
- stays workflow_dispatch-only by default, so it does not change existing CI gates

Project link:
- https://github.com/aak204/MCP-Trust-Kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional, manually-triggered security scanning workflow that integrates MCP Trust Kit for surface-risk analysis.

* **Documentation**
  * Updated README with details about the new optional CI hardening workflow and how to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->